### PR TITLE
Fix bucket name casing

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Open the following file in your browser: `demo/web/index.html`
 
 If you have the [`awslocal`](https://github.com/localstack/awscli-local) command line installed, you can browse the contents of the local S3 bucket via:
 ```
-awslocal s3 ls s3://archiveBucket/
+awslocal s3 ls s3://archivebucket/
 ```
 
 ## License

--- a/serverless.yml
+++ b/serverless.yml
@@ -72,7 +72,7 @@ resources:
     archiveBucket:
       Type: AWS::S3::Bucket
       Properties:
-        BucketName: archiveBucket
+        BucketName: archivebucket
     requestQueue:
       Type: AWS::SQS::Queue
       Properties:


### PR DESCRIPTION
Upper case letters create invalid bucket names. This PR fixes the documentation and serverless config