### PR TITLE
Override host to fix IPv6 resolution on mac

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -48,6 +48,7 @@ custom:
   accountID: '000000000000'
   localstack:
     stages: [local]
+    host: http://127.0.0.1
     debug: true
     # Note: enable this configuration to automatically start up a LocalStack container in the background
 #    autostart: true


### PR DESCRIPTION
The localstack quickstart tutorial fails on latest mac (osx 13.1) due to the default resolution of `localhost` using IPv6. Serverless is expecting to find localstack running at `::1` (`localhost` on IPv6), when it's running at `127.0.0.1` (`localhost` on IPv4). This is the error you see: https://github.com/localstack/serverless-localstack/issues/125

This forces serverless to connect using IPv4. 