### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,16 +17,16 @@ The sample app illustrates a typical Web application scenario with asynchronous 
 
 Note: Please make sure to pull and start the `latest` LocalStack Docker image. At the time of writing (2023-02-01), the demo requires some features that were only recently added to LocalStack and are not part of a tagged release version yet.
 
-## Installing
+## Running LocalStack
 
-Install the dependencies using this command:
+Use the `localstack` CLI command to get started:
 ```
-make install
+localstack start
 ```
 
-## Running
+## Installing dependencies & running the application
 
-To deploy and start the application locally in LocalStack:
+To install the dependencies, deploy and start the application locally in LocalStack:
 ```
 make deploy
 ```


### PR DESCRIPTION
I noticed that `make deploy` contains 'npm install' and 'npm install -g serverless', the same as `make install`, so I removed the extra step