### PR TITLE
Serverless syntax update | exclude -> patterns

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -38,10 +38,10 @@ provider:
 
 package:
   excludeDevDependencies: true
-  exclude:
-    - ./**
-    - "!demo/**"
-    - "!node_modules/uuid/**"
+  patterns:
+    - "!./**"
+    - "demo/**"
+    - "node_modules/uuid/**"
 
 custom:
   region: us-east-1


### PR DESCRIPTION
Serverless was throwing a deprecation warning that was blocking the demo from running. This was due to an [update in the Serverless syntax.](https://www.serverless.com/framework/docs/providers/aws/guide/packaging)(You'll have to scroll a little or search for "patterns") After the syntax was updated, the demo ran without issue.



**Before the fix:**
---
<img width="881" alt="before_the_fix" src="https://user-images.githubusercontent.com/42548400/235523979-3fffb17f-8181-4fab-8daf-302d4062937a.png">



**After the fix:**
---
<img width="402" alt="after_the_fix" src="https://user-images.githubusercontent.com/42548400/235524017-cbd13fe6-3454-4f8c-8ca5-1a361bedc16c.png">
