### PR TITLE
Pin awslocal command output to JSON

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ deploy:          ## Deploy the app
 
 send-request:    ## Send a test request to the deployed application
 	@echo Looking up API ID from deployed API Gateway REST APIs ...; \
-		apiId=$$(awslocal apigateway get-rest-apis | jq -r '.items[] | select(.name="local-localstack-demo") | .id'); \
+		apiId=$$(awslocal apigateway get-rest-apis --output json | jq -r '.items[] | select(.name="local-localstack-demo") | .id'); \
 		echo Sending request to API Gateway REST APIs ID "$$apiId" ...; \
 		requestID=$$(curl -s -d '{}' http://$$apiId.execute-api.localhost.localstack.cloud:4566/local/requests | jq -r .requestID); \
 		echo "Received request ID '$$requestID'"; \

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ deploy:          ## Deploy the app
 		SLS_DEBUG=1 serverless deploy --stage local
 
 send-request:    ## Send a test request to the deployed application
+	@which jq || (echo "jq was not found. Please install it (https://jqlang.github.io/jq/download/) and try again." && exit 1)
 	@echo Looking up API ID from deployed API Gateway REST APIs ...; \
 		apiId=$$(awslocal apigateway get-rest-apis --output json | jq -r '.items[] | select(.name="local-localstack-demo") | .id'); \
 		echo Sending request to API Gateway REST APIs ID "$$apiId" ...; \

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ The sample app illustrates a typical Web application scenario with asynchronous 
 * Docker
 * Node.js / `yarn`
 * `make`
+* (optional) jq
 
 Note: Please make sure to pull and start the `latest` LocalStack Docker image. At the time of writing (2023-02-01), the demo requires some features that were only recently added to LocalStack and are not part of a tagged release version yet.
 


### PR DESCRIPTION
# Motivation
Pinned awslocal command's output to JSON as not all user's aws-cli output format is configured to JSON, so this will throw an error for them.

# Changes
- [x] add json pin into aws command
- [x] check jq before running send-request target