### PR TITLE
Fix CI by updating platform orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
-version: '2.1'
+version: 2.1
 
 orbs:
-  localstack: localstack/platform@1.0.1
+  localstack: localstack/platform@2.0.0
 
 jobs:
   localstack-test:


### PR DESCRIPTION
# Motivation

A [previous pipeline run](https://app.circleci.com/pipelines/github/localstack/localstack-demo/108/workflows/f749cf62-5109-46b5-b2fc-9ddd15825e4f) has failed because of an incorrect docker command when starting LocalStack:

```
Unexpected error when attempting to determine container port status: ('Docker process returned with errorcode 125', b'', b"docker: Invalid ip address: 0.\nSee 'docker run --help'.\n")
ERROR: '['docker', 'create', '--rm', '--name', 'localstack_main', '-v', '/home/circleci/.cache/localstack-cli/license.json:/etc/localstack/conf.d/licens e.json:ro', '-v', '/home/circleci/.cache/localstack-cli/machine.json:/var/lib/localstack/cache/mac hine.json:ro', '-v', '/home/circleci/.cache/localstack/volume:/var/lib/localstack', '-v', '/var/run/docker.sock:/var/run/docker.sock', '-p', '127.0.0.1:4510-4560:4510-4560', '-p', '127.0.0.1:4566:4566', '-p', '127.0.0.1:443:443', '-e', 'LOCALSTACK_API_KEY=************', '-e', 'EXTERNAL_SERVICE_PORTS_START=4510', '-e', 'EXTERNAL_SERVICE_PORTS_END=4560', '-e', 'DOCKER_HOST=unix:///var/run/docker.sock', '-e', 'CI=true', '-e', 'CI_PROJECT=ci-demo-1', '-e', 'DNS_ADDRESS=0', '-e', 'ACTIVATE_PRO=1', '-e', 'GATEWAY_LISTEN=:4566,:443', '-d', 'localstack/localstack:latest']': exit code 125; output: b"unknown shorthand flag: 'd' in -d\nSee 'docker create --help'.\n"
```

It seems an extra `-d` flag is being added to the `docker create` command. This is likely related to some changes in LocalStack that `create` the container before `start`ing, rather than calling `docker run`.

# Changes

* Update the localstack platform orb to invoke LocalStack with `localstack start -d`.
