### PR TITLE
Major: rename default container name to localstack-main

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
       - run:
           name: Deploy app and run test request
           command: |
-            docker logs localstack_main
+            docker logs localstack-main
             awslocal s3 mb s3://test123
             awslocal s3 ls
             make install
@@ -24,7 +24,7 @@ jobs:
             make web &
             make send-request
             code=$?
-            docker logs localstack_main
+            docker logs localstack-main
             exit $code
 
 workflows:


### PR DESCRIPTION
# Motivation

Hyphens are not allowed in URLs. When addressing the LocalStack container over a docker network, the container name resolves to the IP address of the container. This is a problem in particular for boto3 which refuses to connect.

# Changes

This PR updates usages of `localstack_main` to `localstack-main`.
