### PR TITLE
Migrate to AWS_ENDPOINT_URL

### DIFF
--- a/demo/lambdas/app.js
+++ b/demo/lambdas/app.js
@@ -1,16 +1,15 @@
 const uuidv4 = require('uuid/v4');
 const AWS = require('aws-sdk');
 
-const LOCALSTACK_HOSTNAME = process.env.LOCALSTACK_HOSTNAME;
-const ENDPOINT = `http://${LOCALSTACK_HOSTNAME}:4566`;
-if (LOCALSTACK_HOSTNAME) {
+const AWS_ENDPOINT_URL = process.env.AWS_ENDPOINT_URL;
+if (AWS_ENDPOINT_URL) {
     process.env.AWS_SECRET_ACCESS_KEY = 'test';
     process.env.AWS_ACCESS_KEY_ID = 'test';
 }
 
 const DYNAMODB_TABLE = 'appRequests';
 const QUEUE_NAME = 'requestQueue';
-const CLIENT_CONFIG = LOCALSTACK_HOSTNAME ? {endpoint: ENDPOINT} : {};
+const CLIENT_CONFIG = AWS_ENDPOINT_URL ? {endpoint: AWS_ENDPOINT_URL} : {};
 
 const connectSQS = () => new AWS.SQS(CLIENT_CONFIG);
 const connectDynamoDB = () => new AWS.DynamoDB(CLIENT_CONFIG);

--- a/demo/lambdas/processing.py
+++ b/demo/lambdas/processing.py
@@ -1,11 +1,11 @@
+import datetime
 import os
 import time
 import uuid
-import datetime
+
 import boto3
 
-LOCALSTACK_HOSTNAME = os.environ.get("LOCALSTACK_HOSTNAME")
-ENDPOINT = f'http://{LOCALSTACK_HOSTNAME}:4566'
+AWS_ENDPOINT_URL = os.environ.get("AWS_ENDPOINT_URL")
 
 DYNAMODB_TABLE = 'appRequests'
 S3_BUCKET = os.environ.get('ARCHIVE_BUCKET') or 'archive-bucket'
@@ -43,7 +43,7 @@ def archive_result(event, context=None):
 
 
 def get_client(resource):
-    kwargs = {"endpoint_url": ENDPOINT} if LOCALSTACK_HOSTNAME else {}
+    kwargs = {"endpoint_url": AWS_ENDPOINT_URL} if AWS_ENDPOINT_URL else {}
     return boto3.client(resource, **kwargs)
 
 

--- a/demo/lambdas/worker.rb
+++ b/demo/lambdas/worker.rb
@@ -1,16 +1,15 @@
 require 'aws-sdk-states'
 
-$localstack_hostname = ENV['LOCALSTACK_HOSTNAME']
-$endpoint = "http://#{$localstack_hostname}:4566"
-if $localstack_hostname
+$aws_endpoint_url = ENV['AWS_ENDPOINT_URL']
+if $aws_endpoint_url
     ENV['AWS_SECRET_ACCESS_KEY'] = 'test'
     ENV['AWS_ACCESS_KEY_ID'] = 'test'
 end
 $state_machine_arn = ENV['STATE_MACHINE_ARN']
 
 def triggerProcessing(event:, context:)
-    if $localstack_hostname
-        client = Aws::States::Client.new(:endpoint => $endpoint)
+    if $aws_endpoint_url
+        client = Aws::States::Client.new(:endpoint => $aws_endpoint_url)
     else
         client = Aws::States::Client.new()
     end


### PR DESCRIPTION
Adopt `AWS_ENDPOINT_URL` as the official endpoint variable introduced by AWS.

See https://docs.localstack.cloud/user-guide/tools/transparent-endpoint-injection/

/cc repo maintainer @HarshCasper 